### PR TITLE
empty chatname fix

### DIFF
--- a/telegram-chat-parser.py
+++ b/telegram-chat-parser.py
@@ -43,10 +43,18 @@ mention_types = [
                  "mention_name",
                 ]
 
+null_name_counter = 0
 
 def parse_telegram_to_csv(jdata):
-    chat_name = re.sub(r'[\W_]+', u'', jdata["name"], flags=re.UNICODE)
+    
+    if jdata.get("name") is None:
+        global null_name_counter 
+        null_name_counter += 1
+        chat_name = f"UnnamedChat-{null_name_counter}"
+    else:
+        chat_name = re.sub(r'[\W_]+', u'', jdata.get("name"), flags=re.UNICODE)
     output_filepath = f"{chat_name}.csv"
+
     
     with open(output_filepath, "w", encoding="utf-8") as output_file:
         writer = csv.DictWriter(output_file, columns, dialect="unix", quoting=csv.QUOTE_NONNUMERIC)


### PR DESCRIPTION
On some chats i recieved error: 

`Traceback (most recent call last):
  File "parse.py", line 162, in <module>
    parse_telegram_to_csv(chat)
  File "parse.py", line 48, in parse_telegram_to_csv
    chat_name = re.sub(r'[\W_]+', u'', jdata["name"], flags=re.UNICODE)
KeyError: 'name'
`
and pasring stoped. 
its because, obvious, for idk reason we don't have name in json-document in export-file. I made this fix with global counter of empty chats for script. The fix is rather ugly due to the use of globals, but firstly, the script continues to work, 
and secondly, the usage of global variables is reasonable for this architecture of the script.